### PR TITLE
unixsocket should be passed along to config in order to configure sockets properly

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -127,7 +127,7 @@ class redis (
   class { 'redis::config':
     port                        => $port,
     listen                      => $listen,
-    unixsocket                  => '',
+    unixsocket                  => $unixsocket,
     redis_loglevel              => $redis_loglevel,
     databases                   => $databases,
     save                        => $save,


### PR DESCRIPTION
As the title states, this fix is necessary to have the unixsocket parameter work. 

Currently it will always pass config.pp an empty string which in turn never gets the unixsocket directive into the redis configuration.
